### PR TITLE
Only consider numbers for checking cantera version

### DIFF
--- a/src/spitfire/chemistry/ctversion.py
+++ b/src/spitfire/chemistry/ctversion.py
@@ -11,7 +11,7 @@ def check(qual, major, minor, patch=None):
   
   check_version = major * 100 + minor * 10 + patch
   
-  cv_split = [int(a) for a in cantera.__version__.split('.')]
+  cv_split = [int(a) for a in cantera.__version__.split('.') if a.isdigit()]
   cv_patch = 0 if patch is None else cv_split[2]
   cv_minor = 0 if minor is None else cv_split[1]
   cv = 100 * cv_split[0] + 10 * cv_minor + cv_patch


### PR DESCRIPTION
I compiled Spitfire recently on Ubutnu 22.04. I kept getting errors regarding the cantera version number. I checked, and it looks like the version string from the python3 install of Cantera (pip install cantera) contains a value that the parser in the ctversion.py file bombs on. So I added a filter to only consider numerical values in the version string. After this fix, things worked as expected for me.